### PR TITLE
Add standalone weather and safety report pages

### DIFF
--- a/sicherheitsbericht.html
+++ b/sicherheitsbericht.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sicherheitsbericht</title>
+
+    <!-- React & ReactDOM (UMD) -->
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+
+    <!-- Babel für Inline-JSX-Transpilation -->
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+    <!-- jsPDF & html2canvas -->
+    <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: Arial, Helvetica, sans-serif;
+        background: #f5f6fa;
+      }
+      h1,
+      h2 {
+        margin: 0 0 0.5rem 0;
+      }
+      .container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 1rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+      }
+      form {
+        flex: 1 1 350px;
+        background: #ffffff;
+        border-radius: 1rem;
+        padding: 1.5rem;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+      }
+      label span {
+        font-size: 0.85rem;
+        font-weight: 600;
+      }
+      input,
+      select,
+      textarea {
+        width: 100%;
+        padding: 0.5rem;
+        margin-top: 0.25rem;
+        border: 1px solid #cccccc;
+        border-radius: 0.5rem;
+        font-size: 1rem;
+      }
+      textarea {
+        resize: vertical;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        background: #2563eb;
+        color: #ffffff;
+        padding: 0.6rem 1.2rem;
+        border: none;
+        border-radius: 0.6rem;
+        font-size: 1rem;
+        cursor: pointer;
+      }
+      .btn:hover {
+        background: #1e4fd5;
+      }
+      /* Vorschau (DIN A4) */
+      .preview-wrapper {
+        flex: 1 1 350px;
+        overflow: auto;
+        max-height: calc(100vh - 2rem);
+        background: #ffffff;
+        border-radius: 1rem;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+      }
+      .preview-page {
+        width: 210mm;
+        min-height: 297mm;
+        margin: 0 auto;
+        padding: 1.5rem 2rem;
+      }
+      .preview-page img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 1rem;
+        border: 1px solid #ddd;
+      }
+      @media print {
+        body {
+          background: none;
+        }
+        form,
+        .preview-wrapper {
+          box-shadow: none;
+        }
+        .preview-wrapper {
+          overflow: visible;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+
+    <!-- Die App als Inline-JSX -->
+    <script type="text/babel">
+      const { useState, useRef, useEffect, useMemo } = React;
+      const { jsPDF } = window.jspdf;
+
+      const DIN_A4_WIDTH = 210; // mm
+      const STORAGE_KEY = "sicherheitsbericht_entwurf";
+
+      function SicherheitsberichtApp() {
+        const [reportType, setReportType] = useState("Unfallbericht");
+        const [location, setLocation] = useState("");
+        const [date, setDate] = useState("");
+        const [time, setTime] = useState("");
+        const [description, setDescription] = useState("");
+        const [photoUrl, setPhotoUrl] = useState(null);
+
+        const previewRef = useRef(null);
+
+        // Entwurf laden
+        useEffect(() => {
+          const raw = localStorage.getItem(STORAGE_KEY);
+          if (!raw) return;
+          try {
+            const data = JSON.parse(raw);
+            setReportType(data.reportType || "Unfallbericht");
+            setLocation(data.location || "");
+            setDate(data.date || "");
+            setTime(data.time || "");
+            setDescription(data.description || "");
+            setPhotoUrl(data.photoUrl || null);
+          } catch {}
+        }, []);
+
+        // Entwurf speichern
+        useEffect(() => {
+          const payload = {
+            reportType,
+            location,
+            date,
+            time,
+            description,
+            photoUrl,
+          };
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+        }, [reportType, location, date, time, description, photoUrl]);
+
+        const handlePhotoUpload = (e) => {
+          const file = e.target.files?.[0];
+          if (!file) return;
+          const reader = new FileReader();
+          reader.onload = (ev) => setPhotoUrl(ev.target.result);
+          reader.readAsDataURL(file);
+        };
+
+        const handleGeneratePdf = async () => {
+          if (!previewRef.current) return;
+          const canvas = await html2canvas(previewRef.current, { scale: 2, useCORS: true });
+          const imgData = canvas.toDataURL("image/png");
+          const pdf = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
+          const imgProps = pdf.getImageProperties(imgData);
+          const pdfWidth = DIN_A4_WIDTH;
+          const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+          pdf.addImage(imgData, "PNG", 0, 0, pdfWidth, pdfHeight);
+          const filename = `${reportType}_${date || "Datum"}_${time || "Uhrzeit"}.pdf`;
+          pdf.save(filename);
+        };
+
+        const autogeneratedText = useMemo(() => {
+          if (!date && !time && !location && !description) return "—";
+          switch (reportType) {
+            case "Unfallbericht":
+              return `Am ${date || "____"} um ${time || "____"} Uhr ereignete sich am/im ${location || "____"} ein Unfall.\nBetroffene/r: ______________________________________\nBeschreibung: ${description || "____"}\nMaßnahmen: _________________________________________`;
+            case "Schadensmeldung":
+              return `Schaden festgestellt am ${date || "____"} um ${time || "____"} Uhr, Standort: ${location || "____"}.\nBeschreibung des Schadens: ${description || "____"}\nSofortmaßnahmen: ___________________________________`;
+            case "Beinahe-Unfall":
+              return `Beinahe-Ereignis am ${date || "____"} um ${time || "____"} Uhr, Ort: ${location || "____"}.\nWas beinahe passiert wäre: ${description || "____"}\nVorbeugende Maßnahmen: ______________________________`;
+            case "Dienstübergabe":
+              return `Dienstübergabe am ${date || "____"} um ${time || "____"} Uhr.\nOrt/Posten: ${location || "____"}\nBesondere Vorkommnisse: ${description || "____"}`;
+            default:
+              return description || "—";
+          }
+        }, [reportType, date, time, location, description]);
+
+        return (
+          <div className="container">
+            {/* Formular */}
+            <form onSubmit={(e) => { e.preventDefault(); handleGeneratePdf(); }}>
+              <h1>Sicherheitsbericht erstellen</h1>
+
+              {/* Berichtstyp */}
+              <label>
+                <span>Berichtstyp</span>
+                <select value={reportType} onChange={(e) => setReportType(e.target.value)} required>
+                  <option>Unfallbericht</option>
+                  <option>Schadensmeldung</option>
+                  <option>Beinahe-Unfall</option>
+                  <option>Dienstübergabe</option>
+                </select>
+              </label>
+
+              {/* Datum/Uhrzeit */}
+              <div style={{ display: "flex", gap: "0.75rem" }}>
+                <label style={{ flex: 1 }}>
+                  <span>Datum</span>
+                  <input type="date" value={date} onChange={(e) => setDate(e.target.value)} required />
+                </label>
+                <label style={{ flex: 1 }}>
+                  <span>Uhrzeit</span>
+                  <input type="time" value={time} onChange={(e) => setTime(e.target.value)} required />
+                </label>
+              </div>
+
+              {/* Ort */}
+              <label>
+                <span>Ort</span>
+                <input value={location} onChange={(e) => setLocation(e.target.value)} placeholder="z. B. Werkstor A" required />
+              </label>
+
+              {/* Beschreibung */}
+              <label>
+                <span>Beschreibung / Details</span>
+                <textarea rows="6" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Was genau ist passiert?"></textarea>
+              </label>
+
+              {/* Foto */}
+              <label>
+                <span>Foto anhängen</span>
+                <input type="file" accept="image/*" capture="environment" onChange={handlePhotoUpload} />
+              </label>
+
+              {/* Aktion */}
+              <button className="btn" type="submit">PDF erstellen</button>
+            </form>
+
+            {/* Vorschau */}
+            <div className="preview-wrapper">
+              <div className="preview-page" ref={previewRef}>
+                <h2 style={{ textAlign: "center" }}>{reportType}</h2>
+                <p><strong>Ort:</strong> {location || "—"}</p>
+                <p><strong>Datum:</strong> {date || "—"} &nbsp; <strong>Uhrzeit:</strong> {time || "—"}</p>
+                <p style={{ whiteSpace: "pre-wrap" }}>{autogeneratedText}</p>
+                {photoUrl && <img src={photoUrl} alt="Angehängtes Foto" style={{ marginTop: "1rem", maxHeight: "120mm" }} />}
+              </div>
+            </div>
+          </div>
+        );
+      }
+
+      ReactDOM.createRoot(document.getElementById("root")).render(<SicherheitsberichtApp />);
+    </script>
+  </body>
+</html>

--- a/wetterfrosch-deluxe.html
+++ b/wetterfrosch-deluxe.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WetterFrosch Deluxe 🐸☔</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        /* Allgemeine Stile */
+        body {
+            font-family: 'Roboto', sans-serif;
+            background: linear-gradient(135deg, #3b8d99, #6b6b83, #aa4b6b);
+            color: #ffffff;
+            margin: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+        }
+        .app-container {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+            padding: 20px;
+            max-width: 600px;
+            width: 100%;
+            text-align: center;
+        }
+        header h1 {
+            margin: 0;
+            font-size: 1.8em;
+        }
+        .search-container {
+            display: flex;
+            justify-content: center;
+            margin-top: 10px;
+        }
+        .search-container input {
+            width: 60%;
+            padding: 10px;
+            border: none;
+            border-radius: 6px 0 0 6px;
+            font-size: 1em;
+        }
+        .search-container button {
+            padding: 10px;
+            border: none;
+            background-color: #ff5e57;
+            color: #ffffff;
+            cursor: pointer;
+            font-size: 1em;
+            transition: background-color 0.3s;
+        }
+        .search-container button:first-of-type {
+            border-radius: 0 6px 6px 0;
+        }
+        .search-container button:last-of-type {
+            border-radius: 6px;
+            margin-left: 10px;
+        }
+        .search-container button:hover {
+            background-color: #ff3830;
+        }
+        .unit-toggle {
+            margin-top: 10px;
+        }
+        .wetter-sektion {
+            margin-top: 20px;
+            background: rgba(0, 0, 0, 0.2);
+            padding: 15px;
+            border-radius: 8px;
+        }
+        .wetter-sektion h2 {
+            margin-top: 0;
+        }
+        .wetter-sektion img {
+            width: 80px;
+            height: 80px;
+        }
+        footer {
+            margin-top: 20px;
+            font-size: 0.8em;
+            color: #cccccc;
+        }
+        /* Neue Stile für die Vorhersagekarten */
+        .vorhersage-container {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+        .vorhersage-tag {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 8px;
+            margin: 10px;
+            padding: 10px;
+            width: 150px;
+            text-align: center;
+        }
+        /* Responsives Design */
+        @media (max-width: 600px) {
+            .app-container {
+                width: 90%;
+                padding: 10px;
+            }
+            .search-container input {
+                width: 70%;
+            }
+            .wetter-sektion {
+                padding: 10px;
+            }
+        }
+        /* Fehlernachrichten-Stil */
+        .error-message {
+            color: #ff5e57;
+            margin-top: 10px;
+        }
+        /* Stil für Empfehlungen */
+        .empfehlung {
+            margin-top: 15px;
+            font-style: italic;
+        }
+    </style>
+</head>
+<body>
+    <div class="app-container">
+        <header>
+            <h1>🐸 WetterFrosch Deluxe ☔</h1>
+            <div class="search-container">
+                <input type="text" id="stadt" placeholder="Stadt eingeben..." />
+                <button id="sucheWetter">🔍</button>
+                <button id="standort">📍</button>
+            </div>
+            <div class="unit-toggle">
+                <label for="einheit">Einheit:</label>
+                <select id="einheit">
+                    <option value="metric">°C</option>
+                    <option value="imperial">°F</option>
+                </select>
+            </div>
+            <div id="fehler" class="error-message"></div>
+        </header>
+        <main>
+            <section id="aktuellesWetter" class="wetter-sektion"></section>
+            <section id="vorhersageContainer" class="wetter-sektion"></section>
+        </main>
+        <footer>
+            <p>Erstellt mit ❤️ von Ihrem Namen</p>
+        </footer>
+    </div>
+    <script>
+        const apiKey = "7190bcfcb5c5ecd81d00dfc4e518ea21";
+
+        document.getElementById("sucheWetter").addEventListener("click", () => {
+            const stadt = document.getElementById("stadt").value.trim();
+            document.getElementById("fehler").textContent = "";
+            if (stadt) {
+                fetchKoordinaten(stadt);
+            } else {
+                anzeigenFehler("Bitte geben Sie eine Stadt ein!");
+            }
+        });
+
+        document.getElementById("standort").addEventListener("click", () => {
+            document.getElementById("fehler").textContent = "";
+            if (navigator.geolocation) {
+                navigator.geolocation.getCurrentPosition(
+                    (position) => {
+                        const { latitude, longitude } = position.coords;
+                        fetchWetter(latitude, longitude);
+                    },
+                    () => anzeigenFehler("Standortzugriff wurde verweigert.")
+                );
+            } else {
+                anzeigenFehler("Geolocation wird von Ihrem Browser nicht unterstützt.");
+            }
+        });
+
+        async function fetchKoordinaten(stadt) {
+            try {
+                const url = `https://api.openweathermap.org/geo/1.0/direct?q=${encodeURIComponent(stadt)}&limit=1&appid=${apiKey}`;
+                const response = await fetch(url);
+                if (!response.ok) throw new Error("Netzwerkantwort war nicht ok.");
+                const data = await response.json();
+                if (data.length > 0) {
+                    const { lat, lon } = data[0];
+                    fetchWetter(lat, lon);
+                } else {
+                    anzeigenFehler("Stadt nicht gefunden!");
+                }
+            } catch (error) {
+                console.error("Fehler beim Abrufen der Koordinaten:", error);
+                anzeigenFehler("Fehler beim Abrufen der Koordinaten.");
+            }
+        }
+
+        async function fetchWetter(lat, lon) {
+            try {
+                const einheit = document.getElementById("einheit").value;
+                const url = `https://api.openweathermap.org/data/3.0/onecall?lat=${lat}&lon=${lon}&exclude=minutely,hourly,alerts&units=${einheit}&lang=de&appid=${apiKey}`;
+                const response = await fetch(url);
+                if (!response.ok) throw new Error("Netzwerkantwort war nicht ok.");
+                const data = await response.json();
+                anzeigenAktuellesWetter(data.current, data.timezone, einheit);
+                anzeigenVorhersage(data.daily, einheit, data.timezone);
+            } catch (error) {
+                console.error("Fehler beim Abrufen der Wetterdaten:", error);
+                anzeigenFehler("Fehler beim Abrufen der Wetterdaten.");
+            }
+        }
+
+        function anzeigenAktuellesWetter(current, timezone, einheit) {
+            const aktuellesWetterDiv = document.getElementById("aktuellesWetter");
+            aktuellesWetterDiv.innerHTML = "";
+
+            const { temp, feels_like, humidity, weather, dt, wind_speed, wind_deg, sunrise, sunset, uvi } = current;
+            const beschreibung = weather[0].description;
+            const icon = weather[0].icon;
+
+            // Lokale Zeit berechnen
+            const options = { timeZone: timezone, hour: '2-digit', minute: '2-digit' };
+            const lokaleZeit = new Intl.DateTimeFormat('de-DE', options).format(new Date(dt * 1000));
+
+            // Sonnenaufgang und Sonnenuntergang
+            const sunriseTime = new Intl.DateTimeFormat('de-DE', options).format(new Date(sunrise * 1000));
+            const sunsetTime = new Intl.DateTimeFormat('de-DE', options).format(new Date(sunset * 1000));
+
+            // Windrichtung ermitteln
+            const windRichtung = getWindrichtung(wind_deg);
+
+            // Einheitensymbol
+            const tempEinheit = einheit === "metric" ? "°C" : "°F";
+            const windEinheit = einheit === "metric" ? "m/s" : "mph";
+
+            // Empfehlungen generieren
+            const empfehlung = generiereEmpfehlung(temp, beschreibung);
+
+            aktuellesWetterDiv.innerHTML = `
+                <h2>Aktuelles Wetter (${lokaleZeit})</h2>
+                <img src="https://openweathermap.org/img/wn/${icon}@2x.png" alt="${beschreibung}" />
+                <p>Temperatur: ${temp.toFixed(1)}${tempEinheit} (gefühlt: ${feels_like.toFixed(1)}${tempEinheit})</p>
+                <p>Beschreibung: ${beschreibung}</p>
+                <p>Luftfeuchtigkeit: ${humidity}%</p>
+                <p>Wind: ${wind_speed.toFixed(1)} ${windEinheit} aus ${windRichtung}</p>
+                <p>UV-Index: ${uvi}</p>
+                <p>Sonnenaufgang: ${sunriseTime}</p>
+                <p>Sonnenuntergang: ${sunsetTime}</p>
+                <p class="empfehlung">${empfehlung}</p>
+            `;
+        }
+
+        function anzeigenVorhersage(daily, einheit, timezone) {
+            const vorhersageContainer = document.getElementById("vorhersageContainer");
+            vorhersageContainer.innerHTML = "<h2>5-Tage-Vorhersage</h2>";
+
+            const vorhersageDiv = document.createElement("div");
+            vorhersageDiv.className = "vorhersage-container";
+
+            const tempEinheit = einheit === "metric" ? "°C" : "°F";
+
+            daily.slice(1, 6).forEach((tag) => {
+                const options = { timeZone: timezone, weekday: 'long', day: 'numeric', month: 'numeric' };
+                const datum = new Intl.DateTimeFormat('de-DE', options).format(new Date(tag.dt * 1000));
+                const { day, night } = tag.temp;
+                const beschreibung = tag.weather[0].description;
+                const icon = tag.weather[0].icon;
+                const pop = tag.pop * 100; // Niederschlagswahrscheinlichkeit in Prozent
+
+                const tagDiv = document.createElement("div");
+                tagDiv.className = "vorhersage-tag";
+                tagDiv.innerHTML = `
+                    <h3>${datum}</h3>
+                    <img src="https://openweathermap.org/img/wn/${icon}@2x.png" alt="${beschreibung}" />
+                    <p>${day.toFixed(1)}${tempEinheit} / ${night.toFixed(1)}${tempEinheit}</p>
+                    <p>${beschreibung}</p>
+                    <p>Niederschlagswahrscheinlichkeit: ${pop.toFixed(0)}%</p>
+                `;
+                vorhersageDiv.appendChild(tagDiv);
+            });
+
+            vorhersageContainer.appendChild(vorhersageDiv);
+        }
+
+        function generiereEmpfehlung(temp, beschreibung) {
+            let empfehlung = "";
+
+            if (temp >= 25) {
+                empfehlung += "Es ist heiß. Tragen Sie leichte Kleidung und trinken Sie viel Wasser.";
+            } else if (temp >= 15) {
+                empfehlung += "Angenehmes Wetter. Eine Jacke könnte nützlich sein.";
+            } else if (temp >= 5) {
+                empfehlung += "Es ist kühl. Ziehen Sie sich warm an.";
+            } else {
+                empfehlung += "Es ist kalt. Tragen Sie warme Kleidung und denken Sie an eine Mütze und Handschuhe.";
+            }
+
+            if (beschreibung.includes("Regen")) {
+                empfehlung += " Vergessen Sie nicht, einen Regenschirm mitzunehmen.";
+            } else if (beschreibung.includes("Schnee")) {
+                empfehlung += " Es könnte schneien. Seien Sie vorsichtig auf den Straßen.";
+            } else if (beschreibung.includes("Gewitter")) {
+                empfehlung += " Gewitter möglich. Bleiben Sie nach Möglichkeit drinnen.";
+            }
+
+            return empfehlung;
+        }
+
+        function getWindrichtung(deg) {
+            const richtungen = ["N", "NO", "O", "SO", "S", "SW", "W", "NW"];
+            const index = Math.round(((deg %= 360) < 0 ? deg + 360 : deg) / 45) % 8;
+            return richtungen[index];
+        }
+
+        function anzeigenFehler(nachricht) {
+            const fehlerDiv = document.getElementById("fehler");
+            fehlerDiv.textContent = nachricht;
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a styled WetterFrosch Deluxe single-page app that queries OpenWeather for current conditions and forecasts
- add a Sicherheitsbericht generator with a React-based form, live preview, and PDF export helpers

## Testing
- not run (static files)

------
https://chatgpt.com/codex/tasks/task_e_68e911ef82888321b9b52b0c0cc808fd