### PR TITLE
Add 'Regel-Check' report option to sicherheitsbericht.html

### DIFF
--- a/sicherheitsbericht.html
+++ b/sicherheitsbericht.html
@@ -192,6 +192,8 @@
               return `Beinahe-Ereignis am ${date || "____"} um ${time || "____"} Uhr, Ort: ${location || "____"}.\nWas beinahe passiert wäre: ${description || "____"}\nVorbeugende Maßnahmen: ______________________________`;
             case "Dienstübergabe":
               return `Dienstübergabe am ${date || "____"} um ${time || "____"} Uhr.\nOrt/Posten: ${location || "____"}\nBesondere Vorkommnisse: ${description || "____"}`;
+            case "Regel-Check":
+              return description || "Bitte den Regel-Check-Text ergänzen.";
             default:
               return description || "—";
           }
@@ -216,6 +218,7 @@
                   <option>Schadensmeldung</option>
                   <option>Beinahe-Unfall</option>
                   <option>Dienstübergabe</option>
+                  <option>Regel-Check</option>
                 </select>
               </label>
 
@@ -223,11 +226,21 @@
               <div style={{ display: "flex", gap: "0.75rem" }}>
                 <label style={{ flex: 1 }}>
                   <span>Datum</span>
-                  <input type="date" value={date} onChange={(e) => setDate(e.target.value)} required />
+                  <input
+                    type="date"
+                    value={date}
+                    onChange={(e) => setDate(e.target.value)}
+                    required={reportType !== "Regel-Check"}
+                  />
                 </label>
                 <label style={{ flex: 1 }}>
                   <span>Uhrzeit</span>
-                  <input type="time" value={time} onChange={(e) => setTime(e.target.value)} required />
+                  <input
+                    type="time"
+                    value={time}
+                    onChange={(e) => setTime(e.target.value)}
+                    required={reportType !== "Regel-Check"}
+                  />
                 </label>
               </div>
 
@@ -238,7 +251,7 @@
                   value={location}
                   onChange={(e) => setLocation(e.target.value)}
                   placeholder="z. B. Werkstor A"
-                  required
+                  required={reportType !== "Regel-Check"}
                 />
               </label>
 
@@ -249,7 +262,11 @@
                   rows="6"
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
-                  placeholder="Was genau ist passiert?"
+                  placeholder={
+                    reportType === "Regel-Check"
+                      ? "Hier den vollständigen Regel-Check einfügen"
+                      : "Was genau ist passiert?"
+                  }
                 ></textarea>
               </label>
 


### PR DESCRIPTION
### Motivation
- Provide a freeform "Regel-Check" report type for entering long-form rule checks that should not require date/time/location fields. 
- Make the in-app preview and generated PDF content accept a pure text rule-check entry and show a helpful placeholder for that use case. 
- Reduce friction when users want to paste full rule-check text without filling event-specific fields.

### Description
- Added a new `Regel-Check` option to the `Berichtstyp` select in `sicherheitsbericht.html`. 
- Relaxed `required` on the `date`, `time`, and `location` inputs so they are optional when `reportType === "Regel-Check"`. 
- Updated the `description` textarea placeholder for `Regel-Check` and added a `case "Regel-Check"` branch to the `autogeneratedText` switch to render the freeform rule-check text in the preview.

### Testing
- Started a local HTTP server with `python -m http.server` to serve the static file and it reported serving on port 8000 successfully. 
- Attempted an automated browser interaction (Playwright) to select `Regel-Check`, fill the textarea and capture a screenshot, but the Playwright runs timed out and thus that end-to-end screenshot step failed. 
- Inspected the updated `sicherheitsbericht.html` with `sed`/`nl` to verify the new option and conditional input attributes are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974ca5322ec8321a17c58d29e752423)